### PR TITLE
android: get bluetooth device name to show in logs

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,8 @@
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <application

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 
 import 'package:qrscan/qrscan.dart' as scanner;
 import 'package:permission_handler/permission_handler.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart' as fble;
 // XXX: move to biometric storage
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:slider_button/slider_button.dart';
@@ -44,6 +45,7 @@ class OpenerHomePageState extends State<OpenerHomePage> {
     bool _openerCall = false;
     String _statusText = "";
     String _logsText = "";
+    String _deviceName = "unsetb device name";
     final logCfg = FLog.getDefaultConfigurations()
 	  ..formatType = FormatType.FORMAT_CUSTOM
 	  ..customClosingDivider = ":"
@@ -83,6 +85,7 @@ class OpenerHomePageState extends State<OpenerHomePage> {
 	this.storage = new FlutterSecureStorage();
 	this.opener = new OpenerApi();
 	readCfg();
+        initDeviceNameFromBluetooth();
     }
 
     initLogs() async {
@@ -100,6 +103,13 @@ class OpenerHomePageState extends State<OpenerHomePage> {
 	    _statusText = "Ready";
 	});
     }
+
+    // get the name of the phone as advertised via bluetooth
+    initDeviceNameFromBluetooth() async {
+	final flutterBlue = fble.FlutterBluePlus.instance;
+	_deviceName = await flutterBlue.name;
+	FLog.debug(text: "bluetooth device name: $_deviceName");
+    }
     
     Future<String> callOpenerApi() async {
 	final hmacKey = cfg["hmac-key"];
@@ -112,10 +122,10 @@ class OpenerHomePageState extends State<OpenerHomePage> {
 
 	// XXX: ideally we would get the "device_name" here but flutter
 	// seems to have no way to get it
-	var info = "unknown";
+	var info = "$_deviceName";
 	if (Platform.isAndroid) {
 	    final androidInfo = await deviceInfo.androidInfo;
-	    info = "${androidInfo.model}/${androidInfo.host}";
+	    info = "$_deviceName ($androidInfo.model}/${androidInfo.host})";
 	}
 	opener.init(host, port, hmacKey, info);
 	

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -246,6 +246,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_blue_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_blue_plus
+      sha256: a977e90b7f9dcece90a95a287f8843e3b9028a61199c41bc279832c096d31d43
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -608,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.0
+  flutter_blue_plus: ^1.5.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Present a human friendly name when calling the opener API. The closest on Android seems to be the bluetooth device name which is typcially "Pixel 6a" or similar.